### PR TITLE
Implement donor profile gate

### DIFF
--- a/charitywallet/app/layout.tsx
+++ b/charitywallet/app/layout.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Analytics } from "@vercel/analytics/react";
 import ThirdwebAutoConnect from "@/components/thirdweb-auto-connect";
 import { AuthProvider } from "@/contexts/auth-context";
+import DonorProfileGate from "@/components/donor-profile-gate";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -59,6 +60,7 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <AuthProvider>
+              <DonorProfileGate />
               <div className="min-h-screen flex flex-col">
                 <main className="flex-1">{children}</main>
               </div>

--- a/charitywallet/components/donor-profile-gate.test.tsx
+++ b/charitywallet/components/donor-profile-gate.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("@/contexts/auth-context", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/hooks/use-incomplete-donor-profile", () => ({
+  __esModule: true,
+  useIncompleteDonorProfile: jest.fn(),
+}));
+
+jest.mock("@/components/new-donor-modal/new-donor-modal", () => ({
+  __esModule: true,
+  default: ({ walletAddress }: { walletAddress: string }) => (
+    <div data-testid="donor-modal">Modal for {walletAddress}</div>
+  ),
+}));
+
+import { useAuth } from "@/contexts/auth-context";
+import { useIncompleteDonorProfile } from "@/hooks/use-incomplete-donor-profile";
+import DonorProfileGate from "./donor-profile-gate";
+
+describe("DonorProfileGate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the modal for an incomplete donor profile", () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { walletAddress: "0xabc", role: "donor" },
+      donor: { wallet_address: "0xabc" },
+    });
+    (useIncompleteDonorProfile as jest.Mock).mockReturnValue({
+      isIncomplete: true,
+    });
+
+    render(<DonorProfileGate />);
+    expect(screen.getByTestId("donor-modal")).toBeInTheDocument();
+  });
+
+  it("does not render for charity login", () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { walletAddress: "0xabc", role: "charity" },
+      donor: null,
+    });
+    (useIncompleteDonorProfile as jest.Mock).mockReturnValue({
+      isIncomplete: false,
+    });
+
+    const { container } = render(<DonorProfileGate />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+

--- a/charitywallet/components/donor-profile-gate.tsx
+++ b/charitywallet/components/donor-profile-gate.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAuth } from "@/contexts/auth-context";
+import { useIncompleteDonorProfile } from "@/hooks/use-incomplete-donor-profile";
+import DonorProfileModal from "@/components/new-donor-modal/new-donor-modal";
+
+/**
+ * Gate component that shows the donor profile modal when a logged in donor
+ * has not completed their profile yet.
+ */
+export default function DonorProfileGate() {
+  const { user, donor } = useAuth();
+  const { isIncomplete } = useIncompleteDonorProfile(donor?.wallet_address);
+
+  const [open, setOpen] = useState(false);
+
+  // Open the modal whenever we detect an incomplete profile.
+  useEffect(() => {
+    if (user && donor && isIncomplete) {
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  }, [user, donor, isIncomplete]);
+
+  if (!user || (user.role && user.role !== "donor") || !donor || !isIncomplete) {
+    return null;
+  }
+
+  return (
+    <DonorProfileModal
+      walletAddress={donor.wallet_address}
+      open={open}
+      onClose={() => setOpen(false)}
+    />
+  );
+}
+

--- a/charitywallet/contexts/auth-context.tsx
+++ b/charitywallet/contexts/auth-context.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/app/actions/auth";
 
 interface AuthContextProps {
-  user: { walletAddress: string } | null;
+  user: { walletAddress: string; role?: "donor" | "charity" } | null;
   donor: any | null;
   loginDonor: (params: VerifyLoginPayloadParams) => Promise<void>;
   loginCharity: (params: VerifyLoginPayloadParams) => Promise<void>;
@@ -28,7 +28,9 @@ interface AuthContextProps {
 const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<{ walletAddress: string } | null>(null);
+  const [user, setUser] = useState<
+    { walletAddress: string; role?: "donor" | "charity" } | null
+  >(null);
   const [donor, setDonor] = useState<any | null>(null);
   const activeAccount = useActiveAccount();
 
@@ -50,7 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const loginDonor = async (params: VerifyLoginPayloadParams) => {
     const walletAddress = params.payload.address.toLowerCase();
     await loginDonorServer(params);
-    setUser({ walletAddress });
+    setUser({ walletAddress, role: "donor" });
     const updatedDonor = await getDonorByWallet(walletAddress);
     setDonor(updatedDonor);
   };
@@ -59,7 +61,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const loginCharity = async (params: VerifyLoginPayloadParams) => {
     const walletAddress = params.payload.address.toLowerCase();
     await loginCharityServer(params);
-    setUser({ walletAddress });
+    setUser({ walletAddress, role: "charity" });
     // UPDATE CHARITY SPECIFIC STATE HERE
   };
 


### PR DESCRIPTION
## Summary
- gate donor-only areas with new DonorProfileGate client component
- allow `AuthProvider` to persist a login role
- surface gate in the main layout
- test DonorProfileGate behaviour

## Testing
- `pnpm test` *(fails: Connect Timeout Error)*